### PR TITLE
Mark iconv as a required PHP extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         }
     ],
     "require": {
+        "ext-iconv": "*",
         "php": ">=5.5.9",
         "symfony/polyfill-mbstring": "~1.0"
     },


### PR DESCRIPTION
Var-dumper requires the iconv extension. I was using it on a freshly installed PHP instance and got the following fatal error:

> Error: Call to undefined function Symfony\Component\VarDumper\Dumper\iconv_strlen() in Symfony\Component\VarDumper\Dumper\CliDumper->dumpString() (line 172 of vendor/symfony/var-dumper/Dumper/CliDumper.php).
