### PR TITLE
No such return type void

### DIFF
--- a/Dumper/ServerDumper.php
+++ b/Dumper/ServerDumper.php
@@ -50,7 +50,7 @@ class ServerDumper implements DataDumperInterface
     /**
      * {@inheritdoc}
      */
-    public function dump(Data $data, $output = null): void
+    public function dump(Data $data, $output = null)
     {
         set_error_handler(array(self::class, 'nullErrorHandler'));
 


### PR DESCRIPTION
The return type used here will throw an error:

```
Fatal error: Uncaught TypeError: Return value of Symfony\Component\VarDumper\Dumper\ServerDumper::dump() must be an instance of Symfony\Component\VarDumper\Dumper\void, none returned
```

This PR simply removes it.