### PR TITLE
ClassStub closure fix

### DIFF
--- a/Caster/ClassStub.php
+++ b/Caster/ClassStub.php
@@ -54,9 +54,13 @@ class ClassStub extends ConstStub
             }
 
             if (\is_array($r)) {
-                try {
-                    $r = new \ReflectionMethod($r[0], $r[1]);
-                } catch (\ReflectionException $e) {
+                if (false === strpos($r[1], '{closure}')) {
+                    try {
+                        $r = new \ReflectionMethod($r[0], $r[1]);
+                    } catch (\ReflectionException $e) {
+                        $r = new \ReflectionClass($r[0]);
+                    }
+                } else {
                     $r = new \ReflectionClass($r[0]);
                 }
             }

--- a/Tests/Caster/ClassStubTest.php
+++ b/Tests/Caster/ClassStubTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Caster\ClassStub;
+
+require_once \dirname(__DIR__).'/Fixtures/SimpleClass.php';
+
+class ClassStubTest extends TestCase
+{
+    /**
+     * @param $identifier
+     * @param $callable
+     * @param $result
+     *
+     * @dataProvider getIdentifiers
+     */
+    public function testConstruct($identifier, $callable, $result)
+    {
+        $stub = new ClassStub($identifier, $callable);
+
+        $this->assertEquals(serialize($result), $stub->serialize());
+    }
+
+    public function getIdentifiers()
+    {
+        $baseDir = \dirname(__DIR__);
+
+        return [
+            ['\stdClass', null, [
+                '',
+                0,
+                0,
+                1,
+                '\stdClass',
+                0,
+                0,
+                [],
+            ]],
+            ['\stdClass::staticMethod()', null, [
+                '',
+                0,
+                0,
+                1,
+                '\stdClass::staticMethod()',
+                0,
+                0,
+                [],
+            ]],
+            ['\stdClass->classMethod()', null, [
+                '',
+                0,
+                0,
+                1,
+                '\stdClass->classMethod()',
+                0,
+                0,
+                [],
+            ]],
+            [\SimpleClass::class . '::staticMethod()', null, [
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass::staticMethod()',
+                0,
+                0,
+                [
+                    'file' => $baseDir . '/Fixtures/SimpleClass.php',
+                    'line' => 3,
+                ]
+            ]],
+            [\SimpleClass::class . '->classMethod()', null, [
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass->classMethod()',
+                0,
+                0,
+                [
+                    'file' => $baseDir . '/Fixtures/SimpleClass.php',
+                    'line' => 3,
+                ]
+            ]],
+            [\SimpleClass::class . '->' . \SimpleClass::class . '\{closure}', null, [
+                '',
+                0,
+                0,
+                1,
+                'SimpleClass->SimpleClass\{closure}',
+                0,
+                0,
+                [
+                        'ellipsis' => 10,
+                        'ellipsis-type' => 'class',
+                        'ellipsis-tail' => 1,
+                        'file' => $baseDir . '/Fixtures/SimpleClass.php',
+                        'line' => 3,
+                ],
+            ]],
+        ];
+    }
+}

--- a/Tests/Fixtures/SimpleClass.php
+++ b/Tests/Fixtures/SimpleClass.php
@@ -1,0 +1,21 @@
+<?php
+
+class SimpleClass
+{
+    public static function staticMethod()
+    {
+        return 'static';
+    }
+
+    public function classMethod()
+    {
+        return 'class';
+    }
+
+    public function getClosure()
+    {
+        return function () {
+            return 'closure';
+        };
+    }
+}


### PR DESCRIPTION
If the `ClassStub` needs to work with a class closure, it will throw a `FatalErrorException`. I got this:

```
FatalErrorExceptionError: __debuginfo() must return an array
--
in ClassStub.php line 56
at ReflectionMethod->__construct('\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\ExternalStorageRegistryFactory\'', '\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\{closure}\'') in ClassStub.php line 56
at ClassStub->__construct('identifier' => '\'eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\ExternalStorageRegistryFactory->eZ\\\\Publish\\\\Core\\\\Base\\\\Container\\\\ApiLoader\\\\Storage\\\\{closure}\'', 'callable' => '???') in ExceptionCaster.php line 163
...
```

This bugfix handles this situation.