### PR TITLE
Display fully qualified title

### DIFF
--- a/Dumper/HtmlDumper.php
+++ b/Dumper/HtmlDumper.php
@@ -891,7 +891,7 @@ EOHTML
                 $link = '';
             }
 
-            return sprintf('<abbr title="%s" class=sf-dump-%s>%s</abbr>%s', $v, $style, substr($v, $c + 1), $link);
+            return sprintf('<abbr title="%s" class=sf-dump-%s>%s</abbr>%s', $v, $style, $v, $link);
         } elseif ('protected' === $style) {
             $style .= ' title="Protected property"';
         } elseif ('meta' === $style && isset($attr['title'])) {


### PR DESCRIPTION
We can see the objects with namespace that help us to navigate to the file easily.

Before: These are diffrent `Collection` class
<img width="203" alt="Screen Shot 2019-09-06 at 1 02 37 PM" src="https://user-images.githubusercontent.com/13897936/64409623-eb291f00-d0a6-11e9-82a4-2c994083ef50.png">

Now: we can see the diffrent
<img width="376" alt="Screen Shot 2019-09-06 at 1 02 20 PM" src="https://user-images.githubusercontent.com/13897936/64409702-072cc080-d0a7-11e9-99e1-71918179dcd9.png">