### PR TITLE
Remove unnecessary overflow CSS property

### DIFF
--- a/Dumper/HtmlDumper.php
+++ b/Dumper/HtmlDumper.php
@@ -690,7 +690,6 @@ pre.sf-dump img {
 }
 pre.sf-dump .sf-dump-ellipsis {
     display: inline-block;
-    overflow: visible;
     text-overflow: ellipsis;
     max-width: 5em;
     white-space: nowrap;


### PR DESCRIPTION
Removal of a "overflow" property set to visible while the same property was set to hidden later in the same selector