### PR TITLE
Adds ddc helper function

### DIFF
--- a/Resources/functions/dump.php
+++ b/Resources/functions/dump.php
@@ -41,3 +41,13 @@ if (!function_exists('dd')) {
         exit(1);
     }
 }
+
+if (!function_exists('ddc')) {
+    function ddc($count, ...$vars)
+    {
+        static $c = 0;
+        $c++;
+
+        return ($count == $c) ? dd(...$vars) : dump(...$vars);
+    }
+}


### PR DESCRIPTION
Adds ddc helper function as an exhaustive version of dump.

ddc stands for: Die Dump Count

There is a lot of time when the first call to the dd() is not what we want.
on the other hand, dump() does not have a break and prints out much more than we want.

This is something in between dd and dump.
For example, we want to see what parameters are passed to a method, but that method is called multiple times and the first couple of calls does not matter to us.
Or any other debug a process which involves a loop

```php
<?php

$i = 0;
while (true) {
    $i++;
    ddc(4, $i);         // dumps 1, 2, 3, 4 then dies
    ddc([0, 4], $i);    // same as ddc(4, $i); 
}

$i = 0;
while (true) {
    $i++;
    ddc([2,4], $i);   // dumps 3, 4 (skips 1, 2)
}
```
