### PR TITLE
[VarDumper] Add FFI\CData and FFI\CType support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2.0
+---
+
+ * added `FFI\CData` and `FFI\CType` support
+
 5.4
 ---
 

--- a/Caster/FFICaster.php
+++ b/Caster/FFICaster.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Caster;
+
+use FFI\CData;
+use FFI\CType;
+use Symfony\Component\VarDumper\Cloner\Stub;
+
+/**
+ * Casts FFI extension classes to array representation.
+ *
+ * @author Nesmeyanov Kirill <nesk@xakep.ru>
+ *
+ * @final
+ */
+class FFICaster
+{
+    /**
+     * In case of "char*" contains a string, the length of which depends on
+     * some other parameter, then during the generation of the string it is
+     * possible to go beyond the allowable memory area.
+     *
+     * This restriction serves to ensure that during processing does not take
+     * up the entire allowable memory area.
+     */
+    private const MAX_STRING_LENGTH = 255;
+
+    /**
+     * List of FFI scalar types
+     */
+    private const FFI_SCALAR_TYPES = [
+        CType::TYPE_FLOAT,
+        CType::TYPE_DOUBLE,
+        CType::TYPE_UINT8,
+        CType::TYPE_SINT8,
+        CType::TYPE_UINT16,
+        CType::TYPE_SINT16,
+        CType::TYPE_UINT32,
+        CType::TYPE_SINT32,
+        CType::TYPE_UINT64,
+        CType::TYPE_SINT64,
+        CType::TYPE_BOOL,
+        CType::TYPE_CHAR,
+    ];
+
+    public static function castCData(CData $data, array $args, Stub $stub): array
+    {
+        $type = \FFI::typeof($data);
+        $stub->class = self::getClassName($type, $data);
+
+        return match (true) {
+            self::isScalar($type) => self::castFFIScalar($data),
+            self::isEnum($type) => self::castFFIEnum($data),
+            self::isPointer($type) => self::castFFIPointer($stub, $type, $data),
+            self::isStruct($type) => self::castFFIStruct($type, $data),
+            self::isFunction($type) => self::castFFIFunction($stub, $type, $data),
+            default => $args,
+        };
+    }
+
+    public static function castCType(CType $type, array $args, Stub $stub): array
+    {
+        $stub->class = self::getClassName($type, $type);
+
+        return match (true) {
+            self::isScalar($type) => self::castFFIScalar(),
+            self::isEnum($type) => self::castFFIEnum(),
+            self::isPointer($type) => self::castFFIPointer($stub, $type),
+            self::isStruct($type) => self::castFFIStruct($type),
+            self::isFunction($type) => self::castFFIFunction($stub, $type),
+            default => $args,
+        };
+    }
+
+    private static function isFunction(CType $type): bool
+    {
+        return $type->getKind() === CType::TYPE_FUNC;
+    }
+
+    private static function isPointer(CType $type): bool
+    {
+        return $type->getKind() === CType::TYPE_POINTER;
+    }
+
+    private static function isEnum(CType $type): bool
+    {
+        return $type->getKind() === CType::TYPE_ENUM;
+    }
+
+    private static function isStruct(CType $type): bool
+    {
+        return $type->getKind() === CType::TYPE_STRUCT;
+    }
+
+    private static function isScalar(CType $type): bool
+    {
+        $scalars = self::FFI_SCALAR_TYPES;
+
+        if (\defined('\\FFI\\CType::TYPE_LONG_DOUBLE')) {
+            $scalars[] = CType::TYPE_LONG_DOUBLE;
+        }
+
+        return \in_array($type->getKind(), $scalars, true);
+    }
+
+    private static function castFFIFunction(Stub $stub, CType $type, ?CData $data = null): array
+    {
+        $arguments = [];
+
+        for ($i = 0, $count = $type->getFuncParameterCount(); $i < $count; ++$i) {
+            $arguments[] = self::getTypeName($type->getFuncParameterType($i));
+        }
+
+        $abi = match ($type->getFuncABI()) {
+            CType::ABI_DEFAULT,
+            CType::ABI_CDECL => '[cdecl]',
+            CType::ABI_FASTCALL => '[fastcall]',
+            CType::ABI_THISCALL => '[thiscall]',
+            CType::ABI_STDCALL => '[stdcall]',
+            CType::ABI_PASCAL => '[pascal]',
+            CType::ABI_REGISTER => '[register]',
+            CType::ABI_MS => '[ms]',
+            CType::ABI_SYSV => '[sysv]',
+            CType::ABI_VECTORCALL => '[vectorcall]',
+        };
+
+        $stub->class = $abi . ' callable(' . \implode(', ', $arguments) . '): '
+            . self::getTypeName($type->getFuncReturnType());
+
+        return [Caster::PREFIX_VIRTUAL . 'returnType' => $type->getFuncReturnType()];
+    }
+
+    private static function castFFIPointer(Stub $stub, CType $type, ?CData $data = null): array
+    {
+        $ptr = $type->getPointerType();
+
+        if ($data === null) {
+            return [0 => $ptr];
+        }
+
+        return match ($ptr->getKind()) {
+            CType::TYPE_CHAR => self::castFFIStringValue($data),
+            CType::TYPE_FUNC => self::castFFIFunction($stub, $ptr, $data[0]),
+            default => [Caster::PREFIX_VIRTUAL . 0 => $data[0]],
+        };
+    }
+
+    private static function castFFIStringValue(CData $data): array
+    {
+        $result = [];
+        $trimmed = true;
+
+        for ($i = 0; $i < self::MAX_STRING_LENGTH; ++$i) {
+            $result[$i] = $data[$i];
+
+            if ($result[$i] === "\0") {
+                $trimmed = false;
+                break;
+            }
+        }
+
+        $string = \implode('', $result);
+        $length = \count($result);
+
+        if (!$trimmed) {
+            return match (\strlen($string)) {
+                0 => [],
+                1 => [0 => $string],
+                default => [Caster::PREFIX_VIRTUAL . "[0...$length]" => $string]
+            };
+        }
+
+        return [Caster::PREFIX_VIRTUAL . "[0...$length+]" => $string . '...'];
+    }
+
+    private static function castFFIEnum(?CData $data = null): array
+    {
+        return $data !== [] ? ['cdata' => $data->cdata] : [];
+    }
+
+    private static function castFFIScalar(?CData $data = null): array
+    {
+        if ($data === null) {
+            return [];
+        }
+
+        return ['cdata' => $data->cdata];
+    }
+
+    private static function castFFIStruct(CType $type, ?CData $data = null): array
+    {
+        $result = [];
+
+        foreach ($type->getStructFieldNames() as $name) {
+            $field = $type->getStructFieldType($name);
+            $value = $data === null ? $field : $data->{$name};
+
+            if (self::isScalar($field)) {
+                $result[$field->getName() . ' ' . $name] = $value;
+            } else {
+                $result[$name] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    private static function getTypeName(CType $type): string
+    {
+        return $type->getName();
+    }
+
+    private static function getClassName(CType $type, object $data = null): string
+    {
+        return \vsprintf('%s<%s> size %d align %d', [
+            ($data ?? $type)::class,
+            self::getTypeName($type),
+            $type->getSize(),
+            $type->getAlignment(),
+        ]);
+    }
+}

--- a/Cloner/AbstractCloner.php
+++ b/Cloner/AbstractCloner.php
@@ -187,6 +187,9 @@ abstract class AbstractCloner implements ClonerInterface
         'RdKafka\Topic' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castTopic'],
         'RdKafka\TopicPartition' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castTopicPartition'],
         'RdKafka\TopicConf' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castTopicConf'],
+
+        'FFI\CData' => ['Symfony\Component\VarDumper\Caster\FFICaster', 'castCData'],
+        'FFI\CType' => ['Symfony\Component\VarDumper\Caster\FFICaster', 'castCType'],
     ];
 
     protected $maxItems = 2500;

--- a/Tests/Caster/FFICasterTest.php
+++ b/Tests/Caster/FFICasterTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Caster;
+
+use FFI\CData;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
+
+/**
+ * @author Nesmeyanov Kirill <nesk@xakep.ru>
+ */
+class FFICasterTest extends TestCase
+{
+    use VarDumperTestTrait;
+
+    public function setUp(): void
+    {
+        if (!\extension_loaded('ffi')) {
+            $this->markTestSkipped('FFI not available');
+        }
+
+        if (!\in_array(\ini_get('ffi.enable'), ['1', 'preload'], true)) {
+            $this->markTestSkipped('FFI not enabled');
+        }
+
+        parent::setUp();
+    }
+
+    public function testCastAnonymousStruct(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<struct <anonymous>> size 4 align 4 {
+          +uint32_t x: 0
+        }
+        PHP, \FFI::new('struct { uint32_t x; }'));
+    }
+
+    public function testCastNamedStruct(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<struct Example> size 4 align 4 {
+          +uint32_t x: 0
+        }
+        PHP, \FFI::new('struct Example { uint32_t x; }'));
+    }
+
+    public function testCastAnonymousUnion(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<union <anonymous>> size 4 align 4 {
+          +uint32_t x: 0
+          +uint32_t y: 0
+        }
+        PHP, \FFI::new('union { uint32_t x; uint32_t y; }'));
+    }
+
+    public function testCastNamedUnion(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<union Example> size 4 align 4 {
+          +uint32_t x: 0
+          +uint32_t y: 0
+        }
+        PHP, \FFI::new('union Example { uint32_t x; uint32_t y; }'));
+    }
+
+    public function testCastAnonymousEnum(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<enum <anonymous>> size 4 align 4 {
+          +cdata: 0
+        }
+        PHP, \FFI::new('enum { a, b }'));
+    }
+
+    public function testCastNamedEnum(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<enum Example> size 4 align 4 {
+          +cdata: 0
+        }
+        PHP, \FFI::new('enum Example { a, b }'));
+    }
+
+    public function scalarsDataProvider(): array
+    {
+        return [
+            'int8_t' => ['int8_t', '0', 1, 1],
+            'uint8_t' => ['uint8_t', '0', 1, 1],
+            'int16_t' => ['int16_t', '0', 2, 2],
+            'uint16_t' => ['uint16_t', '0', 2, 2],
+            'int32_t' => ['int32_t', '0', 4, 4],
+            'uint32_t' => ['uint32_t', '0', 4, 4],
+            'int64_t' => ['int64_t', '0', 8, 8],
+            'uint64_t' => ['uint64_t', '0', 8, 8],
+
+            'bool' => ['bool', 'false', 1, 1],
+            'char' => ['char', '"\x00"', 1, 1],
+            'float' => ['float', '0.0', 4, 4],
+            'double' => ['double', '0.0', 8, 8],
+        ];
+    }
+
+    /**
+     * @dataProvider scalarsDataProvider
+     */
+    public function testCastScalar(string $type, string $value, int $size, int $align): void
+    {
+        $this->assertDumpEquals(<<<PHP
+        FFI\CData<$type> size $size align $align {
+          +cdata: $value
+        }
+        PHP, \FFI::new($type));
+    }
+
+    public function testVoidFunction(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        [cdecl] callable(): void {
+          returnType: FFI\CType<void> size 1 align 1 {}
+        }
+        PHP, \FFI::new('void (*)(void)'));
+    }
+
+    public function testIntFunction(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        [cdecl] callable(): uint64_t {
+          returnType: FFI\CType<uint64_t> size 8 align 8 {}
+        }
+        PHP, \FFI::new('unsigned long long (*)(void)'));
+    }
+
+    public function testFunctionWithArguments(): void
+    {
+        $this->assertDumpEquals(<<<'PHP'
+        [cdecl] callable(int32_t, char*): void {
+          returnType: FFI\CType<void> size 1 align 1 {}
+        }
+        PHP, \FFI::new('void (*)(int a, const char* b)'));
+    }
+
+    public function testCompositeStruct(): void
+    {
+        $ffi = \FFI::cdef(<<<'CPP'
+        typedef struct {
+            int x;
+            int y;
+        } Point;
+        typedef struct Example {
+            uint8_t a[32];
+            long b;
+            __extension__ union {
+                __extension__ struct {
+                    short c;
+                    long d;
+                };
+                struct {
+                    Point point;
+                    float e;
+                };
+            };
+            short f;
+            bool g;
+            int (*func)(
+                struct __sub *h
+            );
+        } Example;
+        CPP);
+
+        $var = $ffi->new('Example');
+        $var->func = (static fn (object $p) => 42);
+
+        $this->assertDumpEquals(<<<'PHP'
+        FFI\CData<struct Example> size 64 align 8 {
+          +a: FFI\CData<uint8_t[32]> size 32 align 1 {}
+          +int32_t b: 0
+          +int16_t c: 0
+          +int32_t d: 0
+          +point: FFI\CData<struct <anonymous>> size 8 align 4 {
+            +int32_t x: 0
+            +int32_t y: 0
+          }
+          +float e: 0.0
+          +int16_t f: 0
+          +bool g: false
+          +func: [cdecl] callable(struct __sub*): int32_t {
+            returnType: FFI\CType<int32_t> size 4 align 4 {}
+          }
+        }
+        PHP, $var);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no

Added support of FFI:
```php
$ffi = \FFI::cdef(<<<'CPP'
    typedef struct { int x; int y; } Point;
    typedef struct Example {
        uint8_t array[32];
        long longVal;
        __extension__ union {
            __extension__ struct { short shortVal; };
            struct { Point point; float e; };
        };
        bool boolValue;
        int (*func)(struct __sub *h);
    } Example;
CPP);

$struct = $ffi->new('Example');
$struct->func = (static fn (object $ptr) => 42);

dump($struct);
```

**Before**

```
FFI\CData {#2}
```

**After**

```
FFI\CData<struct Example> size 64 align 8 {#2
  +array: FFI\CData<uint8_t[32]> size 32 align 1 {#18}
  +int32_t longVal: 0
  +int16_t shortVal: 0
  +point: FFI\CData<struct <anonymous>> size 8 align 4 {#17
    +int32_t x: 0
    +int32_t y: 0
  }
  +float e: 0.0
  +bool boolValue: false
  +func: [cdecl] callable(struct __sub*): int32_t {#20
    returnType: FFI\CType<int32_t> size 4 align 4 {#25}
  }
}
```