### PR TITLE
[bugfix] Make possible to create sync tcp-connection

### DIFF
--- a/Dumper/ServerDumper.php
+++ b/Dumper/ServerDumper.php
@@ -29,10 +29,11 @@ class ServerDumper implements DataDumperInterface
      * @param string                     $host             The server host
      * @param DataDumperInterface|null   $wrappedDumper    A wrapped instance used whenever we failed contacting the server
      * @param ContextProviderInterface[] $contextProviders Context providers indexed by context name
+     * @param bool                       $asyncClient      Create async connection to TCP-server
      */
-    public function __construct(string $host, DataDumperInterface $wrappedDumper = null, array $contextProviders = [])
+    public function __construct(string $host, DataDumperInterface $wrappedDumper = null, array $contextProviders = [], bool $asyncClient = true)
     {
-        $this->connection = new Connection($host, $contextProviders);
+        $this->connection = new Connection($host, $contextProviders, $asyncClient);
         $this->wrappedDumper = $wrappedDumper;
     }
 

--- a/Server/Connection.php
+++ b/Server/Connection.php
@@ -30,16 +30,23 @@ class Connection
     private $socket;
 
     /**
+     * @var bool Make connection async
+     */
+    private bool $asyncClient;
+
+    /**
      * @param string                     $host             The server host
      * @param ContextProviderInterface[] $contextProviders Context providers indexed by context name
+     * @param bool                       $asyncClient      Make connection async
      */
-    public function __construct(string $host, array $contextProviders = [])
+    public function __construct(string $host, array $contextProviders = [], bool $asyncClient = true)
     {
         if (!str_contains($host, '://')) {
             $host = 'tcp://'.$host;
         }
 
         $this->host = $host;
+        $this->asyncClient = $asyncClient;
         $this->contextProviders = $contextProviders;
     }
 
@@ -91,7 +98,7 @@ class Connection
     {
         set_error_handler([self::class, 'nullErrorHandler']);
         try {
-            return stream_socket_client($this->host, $errno, $errstr, 3, \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT);
+            return stream_socket_client($this->host, $errno, $errstr, 3,  $this->asyncClient ? \STREAM_CLIENT_CONNECT | \STREAM_CLIENT_ASYNC_CONNECT : \STREAM_CLIENT_CONNECT);
         } finally {
             restore_error_handler();
         }

--- a/VarDumper.php
+++ b/VarDumper.php
@@ -77,7 +77,7 @@ class VarDumper
             case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
                 $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
                 $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
-                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
+                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders(), $_SERVER['VAR_DUMPER_ASYNC'] ?? true);
                 break;
             default:
                 $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();


### PR DESCRIPTION
On some systems creating async TCP connection results in "failed to open stream: Resource temporarily unavailable" exception. To solve this, added `VAR_DUMPER_ASYNC` variable, which is `true` by default, so won't affect default behavior. 

If one faces "failed to open stream: Resource temporarily unavailable" error, he should add `VAR_DUMPER_ASYNC=0` to `.env` file, and problem would be solved.