### PR TITLE
Accept mixed key on DsPairStub

### DIFF
--- a/Caster/DsPairStub.php
+++ b/Caster/DsPairStub.php
@@ -18,7 +18,7 @@ use Symfony\Component\VarDumper\Cloner\Stub;
  */
 class DsPairStub extends Stub
 {
-    public function __construct(string|int $key, mixed $value)
+    public function __construct(mixed $key, mixed $value)
     {
         $this->value = [
             Caster::PREFIX_VIRTUAL.'key' => $key,


### PR DESCRIPTION
`Db\Map` accepts any types as key

Fixes https://github.com/symfony/symfony/issues/52495